### PR TITLE
fix: read README.md with UTF-8 encoding in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,9 @@
 from setuptools import setup, find_packages
+from pathlib import Path
+
+# Lee README.md con codificación UTF-8
+this_directory = Path(__file__).parent
+long_description = (this_directory / "README.md").read_text(encoding="utf-8")
 
 setup(
     name="pystructs",
@@ -6,7 +11,7 @@ setup(
     packages=find_packages(),
     install_requires=[],
     description="Functional utilities for nested data structures and validations",
-    long_description=open("README.md").read(),
+    long_description=long_description,
     long_description_content_type="text/markdown",
     author="albertoh88",
     license="MIT",


### PR DESCRIPTION
📌 Description
This PR fixes the `setup.py` to properly read the README.md file using UTF-8 encoding, preventing UnicodeDecodeError on Windows.

🔄 Type of change
Mark with an x what applies:
- [x] fix (bug fix)
- [ ] feat (new feature)
- [ ] docs (documentation update)
- [ ] refactor (code refactoring without changing functionality)
- [ ] chore (miscellaneous tasks, configs, build, etc.)
- [ ] test (adding or updating tests)

✅ Changes made
- Updated `setup.py` to read README.md with `encoding="utf-8"` using `Path`.

🎯 Motivation
To fix build errors on Windows due to encoding issues when reading README.md.

📊 Impact
No breaking changes. Users can now build the package on Windows without UnicodeDecodeError.

📝 Additional notes
Future improvements could include migrating to `pyproject.toml` for modern builds.